### PR TITLE
feat: borough chip added

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fontsource/roboto": "^5.0.14",
         "@mui/icons-material": "^5.16.6",
         "@mui/material": "^5.16.7",
-        "@mui/styled-engine-sc": "6.0.0-alpha.18",
+        "@mui/styled-engine-sc": "^6.0.0-alpha.18",
         "@nivo/core": "^0.87.0",
         "@nivo/geo": "^0.86.0",
         "@observablehq/plot": "^0.6.16",
@@ -23,7 +23,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "sass": "^1.76.0",
-        "styled-components": "^6.1.12",
+        "styled-components": "^6.1.13",
         "topojson-client": "^3.1.0",
         "zustand": "5.0.0-rc.2"
       },
@@ -1288,7 +1288,6 @@
       "version": "6.0.0-alpha.18",
       "resolved": "https://registry.npmjs.org/@mui/styled-engine-sc/-/styled-engine-sc-6.0.0-alpha.18.tgz",
       "integrity": "sha512-W3mqR1K01rPL0BVNTgGpIYxdbQ/nTAlwYaohRdmX7FZvbm1yKw9F90OIGxM503dfRMVBi6a/neYPgIUebcGsHw==",
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "csstype": "^3.1.3",
@@ -5236,7 +5235,6 @@
       "version": "6.1.13",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.13.tgz",
       "integrity": "sha512-M0+N2xSnAtwcVAQeFEsGWFFxXDftHUD7XrKla06QbpUMmbmtFBMMTcKWvFXtWxuD5qQkB8iU5gk6QASlx2ZRMw==",
-      "license": "MIT",
       "dependencies": {
         "@emotion/is-prop-valid": "1.2.2",
         "@emotion/unitless": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@fontsource/roboto": "^5.0.14",
     "@mui/icons-material": "^5.16.6",
     "@mui/material": "^5.16.7",
-    "@mui/styled-engine-sc": "6.0.0-alpha.18",
+    "@mui/styled-engine-sc": "^6.0.0-alpha.18",
     "@nivo/core": "^0.87.0",
     "@nivo/geo": "^0.86.0",
     "@observablehq/plot": "^0.6.16",
@@ -25,7 +25,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "sass": "^1.76.0",
-    "styled-components": "^6.1.12",
+    "styled-components": "^6.1.13",
     "topojson-client": "^3.1.0",
     "zustand": "5.0.0-rc.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,20 +6,20 @@ settings:
 
 dependencies:
   '@emotion/react':
-    specifier: ^11.13.0
-    version: 11.13.0(@types/react@18.2.66)(react@18.2.0)
+    specifier: ^11.13.3
+    version: 11.13.3(@types/react@18.2.66)(react@18.2.0)
   '@emotion/styled':
     specifier: ^11.13.0
-    version: 11.13.0(@emotion/react@11.13.0)(@types/react@18.2.66)(react@18.2.0)
+    version: 11.13.0(@emotion/react@11.13.3)(@types/react@18.2.66)(react@18.2.0)
   '@fontsource/roboto':
     specifier: ^5.0.14
     version: 5.0.14
   '@mui/icons-material':
     specifier: ^5.16.6
-    version: 5.16.6(@mui/material@5.16.6)(@types/react@18.2.66)(react@18.2.0)
+    version: 5.16.6(@mui/material@5.16.7)(@types/react@18.2.66)(react@18.2.0)
   '@mui/material':
-    specifier: ^5.16.6
-    version: 5.16.6(@emotion/react@11.13.0)(@emotion/styled@11.13.0)(@types/react@18.2.66)(react-dom@18.2.0)(react@18.2.0)
+    specifier: ^5.16.7
+    version: 5.16.7(@emotion/react@11.13.3)(@emotion/styled@11.13.0)(@types/react@18.2.66)(react-dom@18.2.0)(react@18.2.0)
   '@mui/styled-engine-sc':
     specifier: 6.0.0-alpha.18
     version: 6.0.0-alpha.18(styled-components@6.1.12)
@@ -348,8 +348,8 @@ packages:
     resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
     dev: false
 
-  /@emotion/react@11.13.0(@types/react@18.2.66)(react@18.2.0):
-    resolution: {integrity: sha512-WkL+bw1REC2VNV1goQyfxjx1GYJkcc23CRQkXX+vZNLINyfI7o+uUn/rTGPt/xJ3bJHd5GcljgnxHf4wRw5VWQ==}
+  /@emotion/react@11.13.3(@types/react@18.2.66)(react@18.2.0):
+    resolution: {integrity: sha512-lIsdU6JNrmYfJ5EbUCf4xW1ovy5wKQ2CkPRM4xogziOxH1nXxBSjpC9YqbFAP7circxMfYp+6x676BqWcEiixg==}
     peerDependencies:
       '@types/react': '*'
       react: '>=16.8.0'
@@ -385,7 +385,7 @@ packages:
     resolution: {integrity: sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==}
     dev: false
 
-  /@emotion/styled@11.13.0(@emotion/react@11.13.0)(@types/react@18.2.66)(react@18.2.0):
+  /@emotion/styled@11.13.0(@emotion/react@11.13.3)(@types/react@18.2.66)(react@18.2.0):
     resolution: {integrity: sha512-tkzkY7nQhW/zC4hztlwucpT8QEZ6eUzpXDRhww/Eej4tFfO0FxQYWRyg/c5CCXa4d/f174kqeXYjuQRnhzf6dA==}
     peerDependencies:
       '@emotion/react': ^11.0.0-rc.0
@@ -398,7 +398,7 @@ packages:
       '@babel/runtime': 7.25.7
       '@emotion/babel-plugin': 11.12.0
       '@emotion/is-prop-valid': 1.3.1
-      '@emotion/react': 11.13.0(@types/react@18.2.66)(react@18.2.0)
+      '@emotion/react': 11.13.3(@types/react@18.2.66)(react@18.2.0)
       '@emotion/serialize': 1.3.2
       '@emotion/use-insertion-effect-with-fallbacks': 1.1.0(react@18.2.0)
       '@emotion/utils': 1.4.1
@@ -735,7 +735,7 @@ packages:
     resolution: {integrity: sha512-RtsCt4Geed2/v74sbihWzzRs+HsIQCfclHeORh5Ynu2fS4icIKozcSubwuG7vtzq2uW3fOR1zITSP84TNt2GoQ==}
     dev: false
 
-  /@mui/icons-material@5.16.6(@mui/material@5.16.6)(@types/react@18.2.66)(react@18.2.0):
+  /@mui/icons-material@5.16.6(@mui/material@5.16.7)(@types/react@18.2.66)(react@18.2.0):
     resolution: {integrity: sha512-ceNGjoXheH9wbIFa1JHmSc9QVjJUvh18KvHrR4/FkJCSi9HXJ+9ee1kUhCOEFfuxNF8UB6WWVrIUOUgRd70t0A==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -747,13 +747,13 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.25.7
-      '@mui/material': 5.16.6(@emotion/react@11.13.0)(@emotion/styled@11.13.0)(@types/react@18.2.66)(react-dom@18.2.0)(react@18.2.0)
+      '@mui/material': 5.16.7(@emotion/react@11.13.3)(@emotion/styled@11.13.0)(@types/react@18.2.66)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.2.66
       react: 18.2.0
     dev: false
 
-  /@mui/material@5.16.6(@emotion/react@11.13.0)(@emotion/styled@11.13.0)(@types/react@18.2.66)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-0LUIKBOIjiFfzzFNxXZBRAyr9UQfmTAFzbt6ziOU2FDXhorNN2o3N9/32mNJbCA8zJo2FqFU6d3dtoqUDyIEfA==}
+  /@mui/material@5.16.7(@emotion/react@11.13.3)(@emotion/styled@11.13.0)(@types/react@18.2.66)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-cwwVQxBhK60OIOqZOVLFt55t01zmarKJiJUWbk0+8s/Ix5IaUzAShqlJchxsIQ4mSrWqgcKCCXKtIlG5H+/Jmg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
@@ -770,10 +770,10 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.25.7
-      '@emotion/react': 11.13.0(@types/react@18.2.66)(react@18.2.0)
-      '@emotion/styled': 11.13.0(@emotion/react@11.13.0)(@types/react@18.2.66)(react@18.2.0)
+      '@emotion/react': 11.13.3(@types/react@18.2.66)(react@18.2.0)
+      '@emotion/styled': 11.13.0(@emotion/react@11.13.3)(@types/react@18.2.66)(react@18.2.0)
       '@mui/core-downloads-tracker': 5.16.7
-      '@mui/system': 5.16.7(@emotion/react@11.13.0)(@emotion/styled@11.13.0)(@types/react@18.2.66)(react@18.2.0)
+      '@mui/system': 5.16.7(@emotion/react@11.13.3)(@emotion/styled@11.13.0)(@types/react@18.2.66)(react@18.2.0)
       '@mui/types': 7.2.17(@types/react@18.2.66)
       '@mui/utils': 5.16.6(@types/react@18.2.66)(react@18.2.0)
       '@popperjs/core': 2.11.8
@@ -818,7 +818,7 @@ packages:
       styled-components: 6.1.12(react-dom@18.2.0)(react@18.2.0)
     dev: false
 
-  /@mui/styled-engine@5.16.6(@emotion/react@11.13.0)(@emotion/styled@11.13.0)(react@18.2.0):
+  /@mui/styled-engine@5.16.6(@emotion/react@11.13.3)(@emotion/styled@11.13.0)(react@18.2.0):
     resolution: {integrity: sha512-zaThmS67ZmtHSWToTiHslbI8jwrmITcN93LQaR2lKArbvS7Z3iLkwRoiikNWutx9MBs8Q6okKvbZq1RQYB3v7g==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -833,14 +833,14 @@ packages:
     dependencies:
       '@babel/runtime': 7.25.7
       '@emotion/cache': 11.13.1
-      '@emotion/react': 11.13.0(@types/react@18.2.66)(react@18.2.0)
-      '@emotion/styled': 11.13.0(@emotion/react@11.13.0)(@types/react@18.2.66)(react@18.2.0)
+      '@emotion/react': 11.13.3(@types/react@18.2.66)(react@18.2.0)
+      '@emotion/styled': 11.13.0(@emotion/react@11.13.3)(@types/react@18.2.66)(react@18.2.0)
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 18.2.0
     dev: false
 
-  /@mui/system@5.16.7(@emotion/react@11.13.0)(@emotion/styled@11.13.0)(@types/react@18.2.66)(react@18.2.0):
+  /@mui/system@5.16.7(@emotion/react@11.13.3)(@emotion/styled@11.13.0)(@types/react@18.2.66)(react@18.2.0):
     resolution: {integrity: sha512-Jncvs/r/d/itkxh7O7opOunTqbbSSzMTHzZkNLM+FjAOg+cYAZHrPDlYe1ZGKUYORwwb2XexlWnpZp0kZ4AHuA==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -857,10 +857,10 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.25.7
-      '@emotion/react': 11.13.0(@types/react@18.2.66)(react@18.2.0)
-      '@emotion/styled': 11.13.0(@emotion/react@11.13.0)(@types/react@18.2.66)(react@18.2.0)
+      '@emotion/react': 11.13.3(@types/react@18.2.66)(react@18.2.0)
+      '@emotion/styled': 11.13.0(@emotion/react@11.13.3)(@types/react@18.2.66)(react@18.2.0)
       '@mui/private-theming': 5.16.6(@types/react@18.2.66)(react@18.2.0)
-      '@mui/styled-engine': 5.16.6(@emotion/react@11.13.0)(@emotion/styled@11.13.0)(react@18.2.0)
+      '@mui/styled-engine': 5.16.6(@emotion/react@11.13.3)(@emotion/styled@11.13.0)(react@18.2.0)
       '@mui/types': 7.2.17(@types/react@18.2.66)
       '@mui/utils': 5.16.6(@types/react@18.2.66)(react@18.2.0)
       '@types/react': 18.2.66

--- a/src/components/LondonGraph/LondonGraph.tsx
+++ b/src/components/LondonGraph/LondonGraph.tsx
@@ -7,18 +7,6 @@ import londonTopo from "../../data/topo_lad.json";
 import { useBoroughStore } from "../../store";
 import { LondonBoroughs } from "../../types/util";
 
-type EventObject = {
-  color: string;
-  data: { id: string; value: number };
-  formattedValue: string;
-  geometry: { type: string; coordinates: [] };
-  id: LondonBoroughs;
-  label: string;
-  properties: { name: string; empty: number; region: string };
-  type: string;
-  value: number;
-};
-
 export default function LondonGraph() {
   const [data, setData] = useState<null | any>(null);
   const [featuresArray, setFeaturesArray] = useState<undefined | any[]>(

--- a/src/components/TitleBlock/TitleBlock.tsx
+++ b/src/components/TitleBlock/TitleBlock.tsx
@@ -1,0 +1,13 @@
+import { Title } from '../shared/StyledComponents/StyledComponents'
+import './TitleBlock.scss'
+
+export default function TitleBlock() {
+
+    // title text
+    // title subtext
+    // preamble
+
+return <>
+<Title>Empty Homes</Title>
+</>
+}

--- a/src/components/shared/MultiText/MultiText.tsx
+++ b/src/components/shared/MultiText/MultiText.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import "./MultiText.scss";
 import { useBoroughStore } from "../../../store";
+import Chip from "@mui/material/Chip";
 
 interface MultiTextProps {
   headline: string;
@@ -18,7 +19,10 @@ export default function MultiText({ headline, showText }: MultiTextProps) {
   console.log(borough);
   return (
     <section className="multitext">
-      <strong>{headline}</strong>
+      <div className="multitext__headline-wrap">
+        <strong>{headline}</strong>
+        <Chip label={borough} />
+      </div>
       {showTextBool && (
         <div className="multitext__show-text">
           <p className="multitext__text">{showText}</p>

--- a/src/components/shared/StyledComponents/StyledComponents.tsx
+++ b/src/components/shared/StyledComponents/StyledComponents.tsx
@@ -1,0 +1,13 @@
+import { styled, Typography } from "@mui/material";
+
+export const Title = styled(Typography)(() => ({
+  color: "#242424",
+  fontSize: "6rem",
+  fontWeight: 700,
+}));
+
+export const Subtitle = styled(Typography)(() => ({
+  color: "#242424",
+  fontSize: "6rem",
+  fontWeight: 700,
+}));

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,62 @@
+import { ThemeOptions } from "@mui/material"
+
+const getThemeOptions = (): ThemeOptions => {
+
+const themeOptions: ThemeOptions = {
+    // Set default spacing unit to match GOV.UK
+    spacing: 10,
+    typography: {
+      fontFamily: "'Inter', Arial, sans-serif",
+      h1: {
+        fontSize: "3rem",
+        letterSpacing: SPACING_TIGHT,
+        fontWeight: FONT_WEIGHT_BOLD,
+      },
+      h2: {
+        fontSize: "2.25rem",
+        letterSpacing: SPACING_TIGHT,
+        fontWeight: FONT_WEIGHT_BOLD,
+      },
+      h3: {
+        fontSize: "1.5rem",
+        fontWeight: FONT_WEIGHT_BOLD,
+      },
+      h4: {
+        fontSize: "1.188rem",
+        fontWeight: FONT_WEIGHT_SEMI_BOLD,
+      },
+      h5: {
+        fontSize: "1rem",
+        fontWeight: FONT_WEIGHT_SEMI_BOLD,
+      },
+      h6: {
+        fontSize: "1rem",
+        fontWeight: FONT_WEIGHT_SEMI_BOLD,
+      },
+      subtitle1: {
+        fontSize: "1.375rem",
+        lineHeight: LINE_HEIGHT_BASE,
+        color: palette.text.secondary,
+      },
+      subtitle2: {
+        fontSize: "1.188rem",
+        lineHeight: LINE_HEIGHT_BASE,
+        color: palette.text.secondary,
+      },
+      body1: {
+        fontSize: "1.188rem",
+        lineHeight: LINE_HEIGHT_BASE,
+      },
+      body2: {
+        fontSize: "1rem",
+      },
+      body3: {
+        fontSize: "0.913rem",
+      },
+      data: {
+        fontFamily: '"Source Code Pro", monospace',
+      },
+    },
+
+}
+return themeOptions}


### PR DESCRIPTION
Added a Material UI chip component to show which Borough you have selected.

Runs off a Zustand store set up to currently only Set and Get a Borough based on clicking on the Nivo.Rocks Choropleth Map.

This will be used to dynamically alter data on the page